### PR TITLE
Allow approximation for multisim covariance

### DIFF
--- a/microfit/histogram.py
+++ b/microfit/histogram.py
@@ -2041,7 +2041,7 @@ class HistogramGenerator:
         if central_value_hist is None:
             central_value_hist = self._histogram_multi_channel(dataframe)
         # calculate the covariance matrix from the histograms
-        cov = covariance(universe_histograms, central_value_hist.nominal_values)
+        cov = covariance(universe_histograms, central_value_hist.nominal_values, allow_approximation=True, tolerance=1e-10)
         self.logger.debug(f"Calculated covariance matrix for {multisim_weight_column}.")
         self.logger.debug(f"Bin-wise error contribution: {np.sqrt(np.diag(cov))}")
         if self.enable_cache:


### PR DESCRIPTION
In rare but occasional histogram calculations, the multisim universes will produce a covariance matrix that is not exactly PSD. Allowing a proximation with a tight tolerance was shown to fix the issue for the problematic histograms.