### PR TITLE
Fix detvar with extra query

### DIFF
--- a/microfit/histogram/run_hist_generator.py
+++ b/microfit/histogram/run_hist_generator.py
@@ -357,6 +357,7 @@ class RunHistGenerator:
         include_multisim_errors: Optional[bool] = None,
         add_precomputed_detsys: bool = False,
         smooth_detsys_variations: bool = True,
+        include_detsys_variations: Optional[List[str]] = None,
         extra_query: Optional[str] = None,
         scale_to_pot: Optional[float] = None,
         use_sideband: Optional[bool] = None,
@@ -419,6 +420,7 @@ class RunHistGenerator:
             extra_query=extra_query,
             add_precomputed_detsys=add_precomputed_detsys,
             smooth_detsys_variations=smooth_detsys_variations,
+            include_detsys_variations=include_detsys_variations,
         )
         hist.label = "MC"
 

--- a/microfit/signal_generators.py
+++ b/microfit/signal_generators.py
@@ -85,6 +85,7 @@ class SignalOverBackgroundGenerator(HistogramGenerator):
 
     def generate(self, **kwargs):
         add_precomputed_detsys = kwargs.pop("add_precomputed_detsys", False)
+        include_detsys_variations = kwargs.pop("include_detsys_variations", None)
         hist = self.hist_generator.generate(**kwargs)
         # It will have to be a MultiChannelHistogram because we are using a split-channel binning.
         assert isinstance(hist, MultiChannelHistogram), "Histogram must be a MultiChannelHistogram"
@@ -111,7 +112,12 @@ class SignalOverBackgroundGenerator(HistogramGenerator):
 
         # Add the covariance for the detector systematics down here
         if self.detvar_data is not None and add_precomputed_detsys:
-            hist.add_covariance(self.calculate_detector_covariance())
+            extra_query = kwargs.get("extra_query", None)
+            hist.add_covariance(
+                self.calculate_detector_covariance(
+                    extra_query=extra_query, include_variations=include_detsys_variations
+                )
+            )
         if self.extra_mc_covariance is not None:
             hist.add_covariance(self.extra_mc_covariance)
 

--- a/microfit/tests/test_detsys.py
+++ b/microfit/tests/test_detsys.py
@@ -1,0 +1,192 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch, MagicMock
+import pandas as pd
+import numpy as np
+from microfit.histogram import (
+    Binning,
+    MultiChannelBinning,
+    HistogramGenerator,
+    MultiChannelHistogram,
+)
+from microfit.detsys import make_variation_histograms, make_variations
+
+
+class MockLoadRunsDetvar:
+    def __init__(self, mock_df):
+        self.mock_df = mock_df
+
+    def __call__(self, run, dataset, variation, **kwargs):
+        if variation == "cv":
+            return {"mc": self.mock_df}, {}, 1.0
+        elif variation == "up":
+            mock_df_up = self.mock_df.copy()
+            mock_df_up["weights"] *= 1.1
+            return {"mc": mock_df_up}, {}, 1.0
+        elif variation == "down":
+            mock_df_down = self.mock_df.copy()
+            mock_df_down["weights"] *= 0.9
+            return {"mc": mock_df_down}, {}, 1.0
+        else:
+            raise ValueError(f"Unknown variation: {variation}")
+
+
+class TestDetSys(unittest.TestCase):
+    @patch("microfit.detsys.dl.load_runs_detvar")
+    def test_make_variation_histograms(self, mock_load_runs_detvar):
+        # Create a mock dataframe
+        mock_df = pd.DataFrame(
+            {
+                "energy": np.random.lognormal(0, 0.5, 1000),
+                "angle": np.random.uniform(0, 3.14, 1000),
+                "bdt": np.random.uniform(0, 1, 1000),
+                "weights": np.random.uniform(0, 1, 1000),
+            }
+        )
+        mock_df["weights"] *= 0.1 / mock_df["weights"].mean()  # scale weights to have a mean of 0.1
+
+        # Create a mock object that behaves like load_runs_detvar
+        mock_load_runs_detvar.side_effect = MockLoadRunsDetvar(mock_df)
+
+        # Create a binning object
+        binning = Binning("energy", np.linspace(0, 3, 12), "energy")
+
+        # Test the make_variation_histograms function
+        hist_dict = make_variation_histograms(["run1"], "dataset", "cv", binning)
+        cv_hist = hist_dict["mc"]
+        cv_bin_counts = cv_hist.bin_counts
+
+        hist_dict_up = make_variation_histograms(["run1"], "dataset", "up", binning)
+        up_hist = hist_dict_up["mc"]
+        up_bin_counts = up_hist.bin_counts
+
+        hist_dict_down = make_variation_histograms(["run1"], "dataset", "down", binning)
+        down_hist = hist_dict_down["mc"]
+        down_bin_counts = down_hist.bin_counts
+
+        # Check that the bin counts are scaled as expected
+        np.testing.assert_allclose(up_bin_counts, cv_bin_counts * 1.1, rtol=1e-5)
+        np.testing.assert_allclose(down_bin_counts, cv_bin_counts * 0.9, rtol=1e-5)
+
+    def make_test_binning(self, multichannel=False, with_query=False, second_query="matching"):
+        first_channel_binning = Binning("energy", np.linspace(0, 3, 12), "energy")
+        if with_query:
+            first_channel_binning.selection_query = "bdt > 0.5"
+        if not multichannel:
+            return first_channel_binning
+
+        second_channel_binning = Binning.from_config("angle", 10, (0, 3.14), "angle")
+        second_query_string = {
+            "matching": "bdt > 0.5",
+            "non_matching": "bdt < 0.5",
+            "overlapping": "bdt < 0.8",
+        }[second_query]
+        if with_query:
+            second_channel_binning.selection_query = second_query_string
+
+        binning = MultiChannelBinning([first_channel_binning, second_channel_binning])
+        return binning
+
+    @patch("microfit.detsys.dl.load_runs_detvar")
+    def test_make_variations(self, mock_load_runs_detvar):
+        # Create a mock dataframe
+        mock_df = pd.DataFrame(
+            {
+                "energy": np.random.lognormal(0, 0.5, 1000),
+                "angle": np.random.uniform(0, 3.14, 1000),
+                "bdt": np.random.uniform(0, 1, 1000),
+                "weights": np.random.uniform(0, 1, 1000),
+            }
+        )
+        mock_df["weights"] *= 0.1 / mock_df["weights"].mean()  # scale weights to have a mean of 0.1
+
+        # Create a mock object that behaves like load_runs_detvar
+        mock_load_runs_detvar.side_effect = MockLoadRunsDetvar(mock_df)
+
+        # Create a temporary directory for the detvar_cache
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            # Test with a Binning
+            binning = self.make_test_binning(with_query=True)
+            detvar_data_binning = make_variations(
+                ["1", "2", "3"],
+                "dataset",
+                binning,
+                detvar_cache_dir=tmp_dir,
+                make_plots=False,
+                variations=["cv", "up", "down"],
+            )
+            self.assertIsInstance(detvar_data_binning, dict)
+            self.assertIn("variation_hist_data", detvar_data_binning)
+
+            # Test with a MultiChannelBinning
+            multi_binning = self.make_test_binning(
+                multichannel=True, with_query=True, second_query="non_matching"
+            )
+            detvar_data_multi_binning = make_variations(
+                ["1", "2", "3"],
+                "dataset",
+                multi_binning,
+                detvar_cache_dir=tmp_dir,
+                make_plots=False,
+                variations=["cv", "up", "down"],
+            )
+            self.assertIsInstance(detvar_data_multi_binning, dict)
+            self.assertIn("variation_hist_data", detvar_data_multi_binning)
+
+    @patch("microfit.detsys.dl.load_runs_detvar")
+    def test_with_hist_generator(self, mock_load_runs_detvar):
+        """Test detvar_data when passed to a HistogramGenerator"""
+
+        # Make mock data, mock detvar_data and instantiate a HistogramGenerator
+        mock_df = pd.DataFrame(
+            {
+                "energy": np.random.lognormal(0, 0.5, 1000),
+                "angle": np.random.uniform(0, 3.14, 1000),
+                "bdt": np.random.uniform(0, 1, 1000),
+                "weights": np.random.uniform(0, 1, 1000),
+            }
+        )
+
+        mock_df["weights"] *= 0.1 / mock_df["weights"].mean()  # scale weights to have a mean of 0.1
+        mock_load_runs_detvar.side_effect = MockLoadRunsDetvar(mock_df)
+
+        binning = self.make_test_binning(
+            multichannel=True, with_query=True, second_query="non_matching"
+        )
+        detvar_data = make_variations(
+            ["1", "2", "3"],
+            "dataset",
+            binning,
+            detvar_cache_dir=None,
+            make_plots=False,
+            variations=["cv", "up", "down"],
+        )
+
+        hist_gen = HistogramGenerator(mock_df, binning, detvar_data=detvar_data)
+
+        hist_no_detvar = hist_gen.generate()
+        hist_with_detvar = hist_gen.generate(
+            add_precomputed_detsys=True, include_detsys_variations=["cv", "up", "down"]
+        )
+
+        # Assert valid histograms were produced
+        self.assertIsInstance(hist_no_detvar, MultiChannelHistogram)
+        self.assertIsInstance(hist_with_detvar, MultiChannelHistogram)
+
+        # Assert that the covariance matrix is diagonal for the histogram without detector variations,
+        # and non-diagonal for the histogram with detector variations
+        np.testing.assert_array_equal(
+            hist_no_detvar.covariance_matrix, np.diag(np.diag(hist_no_detvar.covariance_matrix))
+        )
+        # There should be non-zero off-diagonal elements in the covariance matrix with detvars
+        self.assertTrue(
+            np.any(
+                hist_with_detvar.covariance_matrix
+                - np.diag(np.diag(hist_with_detvar.covariance_matrix))
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/microfit/tests/test_detsys.py
+++ b/microfit/tests/test_detsys.py
@@ -154,14 +154,15 @@ class TestDetSys(unittest.TestCase):
         binning = self.make_test_binning(
             multichannel=True, with_query=True, second_query="non_matching"
         )
-        detvar_data = make_variations(
-            ["1", "2", "3"],
-            "dataset",
-            binning,
-            detvar_cache_dir=None,
-            make_plots=False,
-            variations=["cv", "up", "down"],
-        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            detvar_data = make_variations(
+                ["1", "2", "3"],
+                "dataset",
+                binning,
+                detvar_cache_dir=tmp_dir,
+                make_plots=False,
+                variations=["cv", "up", "down"],
+            )
 
         hist_gen = HistogramGenerator(mock_df, binning, detvar_data=detvar_data)
 

--- a/microfit/tests/test_histogram.py
+++ b/microfit/tests/test_histogram.py
@@ -232,8 +232,9 @@ class TestHistogram(unittest.TestCase):
                 )
                 # fluctuate the histogram and check that the fluctuated bin counts are distributed according to the covariance matrix
                 fluctuated_counts = []
+                rng = np.random.default_rng(seed=0)
                 for i in range(10000):
-                    fluctuated_hist = hist.fluctuate(seed=i)
+                    fluctuated_hist = hist.fluctuate(rng=rng)
                     self.assertIsExactInstance(fluctuated_hist, HistogramClass)
                     fluctuated_counts.append(fluctuated_hist.bin_counts)
                 fluctuated_counts = np.array(fluctuated_counts)
@@ -288,11 +289,12 @@ class TestHistogram(unittest.TestCase):
                 # To test error propagation, we fluctuate hist1 and hist2 and divide them. The covariance matrix
                 # of the fluctuated divisions should be close to the expected covariance matrix that we get
                 # from the division function.
+                rng = np.random.default_rng(seed=0)
                 for i in range(10000):
-                    fluctuated_hist1 = hist1.fluctuate(seed=i)
+                    fluctuated_hist1 = hist1.fluctuate(rng=rng)
                     # It's important not to repeat seeds here, otherwise the values will be correlated
                     # when they should not be.
-                    fluctuated_hist2 = hist2.fluctuate(seed=i + 10000)
+                    fluctuated_hist2 = hist2.fluctuate(rng=rng)
                     self.assertIsExactInstance(fluctuated_hist1, HistogramClass)
                     self.assertIsExactInstance(fluctuated_hist2, HistogramClass)
                     fluctuated_division = fluctuated_hist1 / fluctuated_hist2
@@ -418,11 +420,12 @@ class TestHistogram(unittest.TestCase):
                 # To test error propagation, we fluctuate hist1 and hist2 and multiply them. The covariance matrix
                 # of the fluctuated multiplications should be close to the expected covariance matrix that we get
                 # from the multiplication function.
+                rng = np.random.default_rng(seed=0)
                 for i in range(10000):
-                    fluctuated_hist1 = hist1.fluctuate(seed=i)
+                    fluctuated_hist1 = hist1.fluctuate(rng=rng)
                     # It's important not to repeat seeds here, otherwise the values will be correlated
                     # when they should not be.
-                    fluctuated_hist2 = hist2.fluctuate(seed=i + 10000)
+                    fluctuated_hist2 = hist2.fluctuate(rng=rng)
                     self.assertIsExactInstance(fluctuated_hist1, HistogramClass)
                     self.assertIsExactInstance(fluctuated_hist2, HistogramClass)
                     fluctuated_multiplication = fluctuated_hist1 * fluctuated_hist2

--- a/microfit/tests/test_parameters.py
+++ b/microfit/tests/test_parameters.py
@@ -3,7 +3,7 @@ import unittest
 from typing import List, Sequence, Union
 from unitpy import Unit, Quantity
 
-from ..parameters import Parameter, ParameterSet
+from microfit.parameters import Parameter, ParameterSet
 
 
 class TestParameter(unittest.TestCase):

--- a/microfit/tests/test_run_hist_generator.py
+++ b/microfit/tests/test_run_hist_generator.py
@@ -1,3 +1,4 @@
+import tempfile
 from typing import Union
 import unittest
 from unittest.mock import patch
@@ -229,13 +230,15 @@ class TestRunHistGenerator(unittest.TestCase):
         )
 
         # Generate mock detvar_data
-        detvar_data = make_variations(
-            ["1", "2", "3"],
-            "dataset",
-            multi_binning,
-            make_plots=False,
-            variations=["cv", "up", "down"],
-        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            detvar_data = make_variations(
+                ["1", "2", "3"],
+                "dataset",
+                multi_binning,
+                make_plots=False,
+                variations=["cv", "up", "down"],
+                detvar_cache_dir=tmp_dir
+            )
 
         # Create mock run data
         mock_rundata = {
@@ -280,13 +283,15 @@ class TestRunHistGenerator(unittest.TestCase):
         )
 
         # Generate mock detvar_data
-        detvar_data = make_variations(
-            ["1", "2", "3"],
-            "dataset",
-            multi_binning,
-            make_plots=False,
-            variations=["cv", "up", "down"],
-        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            detvar_data = make_variations(
+                ["1", "2", "3"],
+                "dataset",
+                multi_binning,
+                make_plots=False,
+                variations=["cv", "up", "down"],
+                detvar_cache_dir=tmp_dir
+            )
 
         # Create mock run data, this time including a signal channel
         mock_rundata = {


### PR DESCRIPTION
* Fixes issue where passing an extra_query to a SignalOverBackgroundGenerator gave unexpected covariance when including detvars
* Adds unit tests for detvar calculation
* Adds unit test that asserts that the fixed SignalOverBackgroundGenerator gives the expected result